### PR TITLE
#163959580 Add Django CORS

### DIFF
--- a/authors/settings.py
+++ b/authors/settings.py
@@ -71,7 +71,7 @@ INSTALLED_APPS = [
 ]
 
 MIDDLEWARE = [
-    # 'corsheaders.middleware.CorsMiddleware',
+    'corsheaders.middleware.CorsMiddleware',
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
@@ -159,7 +159,7 @@ STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'
 CORS_ORIGIN_WHITELIST = (
     '*'
 )
-
+CORS_ORIGIN_ALLOW_ALL = True
 # Tell Django about the custom `User` model we created. The string
 # `authentication.User` tells Django we are referring to the `User` model in
 # the `authentication` module. This module is registered above in a setting


### PR DESCRIPTION
### What does this PR do?
Adds Django CORS to Authors Haven backend.

### Description of Task to be completed?
- [x] Add CORS middleware to the settings.py file
- [x] Enable all hosts to do cross site requests

### How should this be manually tested?
This feature will be tested when calling our backend API using React JS.
     
### Any background context you want to provide?
None

### What are the relevant pivotal tracker stories?
[#163959580](https://www.pivotaltracker.com/n/projects/2235171/stories/163959580)

### Screenshots
CORS MIDDLEWARE setting
![image](https://user-images.githubusercontent.com/10106044/52739328-b60d9000-2fe1-11e9-8962-a7fa5ccfa9a9.png)

CORS ORIGIN ALLOW ALL setting
![image](https://user-images.githubusercontent.com/10106044/52739318-af7f1880-2fe1-11e9-89de-3f5618e37284.png)

## Questions:
Questions and comments are welcome.