### PR TITLE
 #164164484 bug fix for social auth

### DIFF
--- a/authors/apps/authentication/views.py
+++ b/authors/apps/authentication/views.py
@@ -292,6 +292,7 @@ class SocialAuthView(generics.CreateAPIView):
     """Social Authentication class"""
     permission_classes = (AllowAny,)
     serializer_class = SocialAuthSerializer
+    # renderer_classes = (UserJSONRenderer,)
 
     def create(self, request, *args, **kwargs):
         serializer = self.serializer_class(data=request.data)
@@ -355,4 +356,15 @@ class SocialAuthView(generics.CreateAPIView):
         serializer = UserSerializer(user)
         serialized_details = serializer.data
         serialized_details["token"] = user_token
+        user = {
+            "email": serialized_details["email"],
+            "username": serialized_details["email"].split("@")[0],
+            "password": os.getenv("SECRET_PASS"),
+        }
+        reg_user = User.objects.filter(email=serialized_details["email"])
+        if not reg_user:
+            reg_serializer = RegistrationSerializer(data=user)
+            reg_serializer.is_valid(raise_exception=True)
+            reg_serializer.save()
+
         return Response(serialized_details, status.HTTP_200_OK)


### PR DESCRIPTION
#### What does this PR do?

Create a profile for a user upon using social login

#### Description of Task to be completed?

- [x] Create a profile upon first login

#### How should this be manually tested?

1. Clone this repository on your local machine using 

     `git clone https://github.com/andela/ah-robotics.git`
2. Change your working directory to the project's directory using 
     
     >`cd ah-robotics`
3. Change to the specific branch `bg-fix-social-auth-#164046332` using 

     >`git checkout bg-fix-social-auth-#164046332`
4. Create a virtual environment using the following command: 
     
     >`python3 -m virtualenv env`
5. Activate the virtual environment using 
     
     >`source env/bin/activate`
6. Install all the requirements using 
     
     >`pip install -r requirements.txt`

    #### Database setup

    Ensure [PostgreSQL](https://www.postgresql.org/) is installed and is running, follow these steps to create a new user and a database which will be used in the application.

    1. Start the postgres database server using the command:
      
        `pg_ctl -D /usr/local/var/postgres start`
    
    2. Run psql interactive terminal
    
        `psql postgres`
    
    3. Create a new user:
    
        `CREATE USER sample_username WITH PASSWORD 'sample_password';`
    
    4. Grant privileges to the user:
    
        `ALTER USER sample_username CREATEDB;`
    
    5. Create a database:
    
        `CREATE DATABASE sample_database_name WITH OWNER sample_username;`
    
    6. Exit psql interactive with the following command: `\q`
    
7. Create a **.env** file and add the following configuration variables

    ```source-json
          source env/bin/activate
          export DB_NAME="database_name"
          export DB_USER="sample_username"
          export DB_PASS="sample_password"
          export DB_HOST="host_name_eg_localhost"
          export DB_PORT="port_number_eg_5432"
          export TIME_DELTA="30"
          export EMAIL_HOST="smtp.gmail.com"
          export EMAIL_PORT=587
          export EMAIL_HOST_USER="user@example.com"
          export EMAIL_HOST_PASSWORD="email_password"
          export PASSWORD_RESET_URL="api/v1/reset_password"
          export CLIENT_DOMAIN="127.0.0.1:8000"
          export CLOUDINARY_NAME="your_cloudinary_name"
          export CLOUDINARY_KEY="your_cloudinary_key"
          export CLOUDINARY_SECRET="your_secret_key"

          export FACEBOOK_APP_ID="obtained_facebook_app_id"
          export FACEBOOK_APP_SECRET="obtained_facebook_app_secret"
          export GOOGLE_KEY="obtained_google_app_secret"
          export GOOGLE_SECRET="obtained_google_secret"
          export TWITTER_KEY="obtained_twitter_key" 
          export TWITTER_SECRET="obtained_twitter_secret"
          export GOOGLE_ACCESS_TOKEN="obtained_google_access_token"
          export FACEBOOK_ACCESS_TOKEN="obtained_facebook_access_token"
          export TWITTER_ACCESS_TOKEN="obtained_twitter_access_token"
          export TWITTER_SECRET_TOKEN="obtained_twitter_access_secret_token"
    ```
    
    > **Note**: The values of some of these variables are private namely the EMAIL_HOST_USER, EMAIL_HOST_PASSWORD and the CLOUDINARY VALUES.  Use your GMAIL email address and password for the  EMAIL_HOST_USER and EMAIL_HOST_PASSWORD respectively. To get Cloudinary values, create an account with Cloudinary and obtain the values.

> The social login values are pinned in the slack channel 

8. Source .env to set the configuration variables in the terminal:

      `source .env`
9. Run migrations through the terminal to create the tables in the database:
      
      (i) Make the migrations using: 
      
      `python manage.py makemigrations`
      
      (ii) Apply the migrations using: 
      
      `python manage.py migrate`

10. Run the following command to collect static files.

    `python manage.py collectstatic`
      
#### Testing the features

1. Run the server from the terminal using: 
    
> `python manage.py runserver`
2. Download [Postman](https://www.getpostman.com/) and after it is installed, open it on your local machine and Paste the URL below to first sign up a user.

> `http://127.0.0.1:8000/api/v1/login/social/` 

3. On the **Headers** section add **Content-type** as the KEY and **_application/json_** as the VALUE.
4. Head over to the **Body** section and select the **raw** option and the add the following payload to the body:

> To login with facebook

    ```
       {
	"provider": "facebook",
	"access_token": "facebook_token"
       }
    ```

> To login with Google

    ```
       {
	"provider": "google-oauth2",
	"access_token": "google_oauth2_token"
       }
    ```

> To login with Twitter

    ```
       {
	"provider": "twitter",
	"access_token": "twitter_access_token",
	"access_token_secret": "twitter_access_secret_token"
       }
    ```
5. The above requests should return a response that contains a valid `JWT-token`

> Sample response

```
      {
    "email": "email_of_signed_in_user",
    "username": "username_of_signed_in_user",
    "token": "valid_JWT_token"
      }
```

#### Any background context you want to provide?

This is a bug-fix to rectify the previous implementation

#### What are the relevant pivotal tracker stories?

[#164164484](https://www.pivotaltracker.com/story/show/164164484)

#### Screenshots

1. Social Authentication with Facebook:

<img width="1128" alt="screenshot 2019-02-21 at 12 21 24" src="https://user-images.githubusercontent.com/6994982/53160421-00da6980-35d9-11e9-92ce-853f5b956d0e.png">

2. Social Authentication with Google:

<img width="1117" alt="screenshot 2019-02-21 at 12 23 55" src="https://user-images.githubusercontent.com/6994982/53160445-0e8fef00-35d9-11e9-9b26-cc1aac04a8e8.png">

3. Social Authentication with Twitter:

<img width="1118" alt="screenshot 2019-02-21 at 12 26 07" src="https://user-images.githubusercontent.com/6994982/53160466-194a8400-35d9-11e9-8b48-359d2efa3b0a.png">
